### PR TITLE
Add Docker support with conditional host binding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.11-slim
+
+# Install system dependencies including FFmpeg
+RUN apt-get update && apt-get install -y \
+    ffmpeg \
+    gcc \
+    g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy requirements first for better caching
+COPY requirements.txt .
+
+# Install Python dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Expose the Flask port
+EXPOSE 5000
+
+# Command to run the application
+CMD ["python", "server.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+services:
+  speechfire:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "127.0.0.1:5000:5000"
+    volumes:
+      - .:/app
+    environment:
+      - FLASK_ENV=development
+      - FLASK_DEBUG=1
+      - DOCKER_ENV=1
+    restart: unless-stopped
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    networks:
+      - speechfire-network
+
+networks:
+  speechfire-network:
+    driver: bridge

--- a/server.py
+++ b/server.py
@@ -65,4 +65,6 @@ def transcribe():
 
 if __name__ == "__main__":
     logging.info(f"Starting server with device: {device}")
-    app.run(debug=True, threaded=True)
+    # Bind to 0.0.0.0 if running in Docker, otherwise localhost
+    host = '0.0.0.0' if os.environ.get('DOCKER_ENV') else '127.0.0.1'
+    app.run(host=host, port=5000, debug=True, threaded=True)


### PR DESCRIPTION
## Summary
- Add Dockerfile with Python 3.11 and FFmpeg dependencies
- Add docker-compose.yml with GPU support and localhost-only binding  
- Update server.py to conditionally bind to 0.0.0.0 in Docker, 127.0.0.1 otherwise
- Includes volume mounting for development workflow

## Test plan
- [ ] Build Docker image successfully
- [ ] Run container and verify server starts
- [ ] Confirm localhost-only access from host
- [ ] Test speech transcription functionality

🤖 Generated with [Claude Code](https://claude.ai/code)