### PR TITLE
Add comprehensive error handling to Firefox extension

### DIFF
--- a/extension-firefox/background.js
+++ b/extension-firefox/background.js
@@ -24,20 +24,11 @@ const stopSound = new Audio(browser.runtime.getURL("sounds/stop.mp3"));
 
 function toggleRecording() {
   if (!isRecording) {
-    // Set the volume of the start sound and play it
-    startSound.volume = volumeLevel;
-    startSound.play();
-
-    // Change icon
-    browser.browserAction.setIcon({ path: "./icon/icon-red.png" });
+    // Don't change icon here - wait for content script confirmation
+    // Just send the command to content script
     isRecording = true;
   } else {
-    // Play the stop recording sound
-    stopSound.volume = volumeLevel;
-    stopSound.play();
-
-    // Stop recording
-    browser.browserAction.setIcon({ path: "./icon/icon-128.png" });
+    // The content script will handle stopping and notify us
     isRecording = false;
   }
 }
@@ -74,5 +65,22 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   } else if (message.action === "updateLanguage") {
     selectedLanguage = message.language;
     console.log(`Language updated: ${selectedLanguage}`);
+  } else if (message.action === "recordingStarted") {
+    // Recording actually started - change icon and play sound
+    startSound.volume = volumeLevel;
+    startSound.play();
+    browser.browserAction.setIcon({ path: "./icon/icon-red.png" });
+    console.log("Recording started - icon changed to red");
+  } else if (message.action === "recordingStopped") {
+    // Recording stopped - change icon back and play sound
+    stopSound.volume = volumeLevel;
+    stopSound.play();
+    browser.browserAction.setIcon({ path: "./icon/icon-128.png" });
+    isRecording = false;
+    console.log("Recording stopped - icon changed to normal");
+  } else if (message.action === "recordingFailed") {
+    // Recording failed - reset state without changing icon
+    isRecording = false;
+    console.log("Recording failed - state reset");
   }
 });

--- a/extension-firefox/content.js
+++ b/extension-firefox/content.js
@@ -19,27 +19,48 @@ chrome.runtime.onMessage.addListener((message) => {
 });
 
 function startRecording() {
-    navigator.mediaDevices.getUserMedia({ audio: true })
-        .then(stream => {
-            mediaRecorder = new MediaRecorder(stream);
-            mediaRecorder.start();
-            console.log("MediaRecorder started");
+    // Test server connection first
+    testServerConnection()
+        .then(serverAvailable => {
+            if (!serverAvailable) {
+                showErrorNotification("Cannot connect to Speechfire server. Please ensure it's running on http://127.0.0.1:5000");
+                // Tell background script recording failed
+                chrome.runtime.sendMessage({ action: "recordingFailed" });
+                return;
+            }
 
-            mediaRecorder.ondataavailable = (event) => {
-                audioChunks.push(event.data);
-            };
+            // Server is available, proceed with recording
+            navigator.mediaDevices.getUserMedia({ audio: true })
+                .then(stream => {
+                    mediaRecorder = new MediaRecorder(stream);
+                    mediaRecorder.start();
+                    console.log("MediaRecorder started");
+                    
+                    // Tell background script recording actually started
+                    chrome.runtime.sendMessage({ action: "recordingStarted" });
 
-            mediaRecorder.onstop = () => {
-                console.log("MediaRecorder stopped");
-                const audioBlob = new Blob(audioChunks, { type: 'audio/wav' });
-                audioChunks = [];
-                sendAudioForTranscription(audioBlob);
-            };
+                    mediaRecorder.ondataavailable = (event) => {
+                        audioChunks.push(event.data);
+                    };
 
-            isRecording = true;
-        })
-        .catch(error => {
-            console.error('Error accessing audio:', error);
+                    mediaRecorder.onstop = () => {
+                        console.log("MediaRecorder stopped");
+                        const audioBlob = new Blob(audioChunks, { type: 'audio/wav' });
+                        audioChunks = [];
+                        sendAudioForTranscription(audioBlob);
+                        
+                        // Tell background script recording stopped
+                        chrome.runtime.sendMessage({ action: "recordingStopped" });
+                    };
+
+                    isRecording = true;
+                })
+                .catch(error => {
+                    console.error('Error accessing audio:', error);
+                    showErrorNotification("Cannot access microphone. Please check permissions.");
+                    // Tell background script recording failed
+                    chrome.runtime.sendMessage({ action: "recordingFailed" });
+                });
         });
 }
 
@@ -54,16 +75,55 @@ function sendAudioForTranscription(audioBlob) {
         // Send the language as a query string parameter
         fetch(`http://127.0.0.1:5000/transcribe?lang=${encodeURIComponent(selectedLanguage)}`, {
             method: 'POST',
-            body: formData
+            body: formData,
+            signal: AbortSignal.timeout(30000) // 30 second timeout for transcription
         })
-        .then(response => response.json())
+        .then(response => {
+            if (!response.ok) {
+                throw new Error(`Server error: ${response.status} ${response.statusText}`);
+            }
+            return response.json();
+        })
         .then(data => {
+            if (data.error) {
+                showErrorNotification(`Transcription failed: ${data.error}`);
+                return;
+            }
             console.log("Transcription received:", data.transcription); // Log transcription for debugging
             if (data.transcription) {
                 pasteTranscription(data.transcription);
+            } else {
+                showErrorNotification("No transcription received from server");
             }
         })
-        .catch(error => console.error('Error:', error));
+        .catch(error => {
+            console.error('Transcription error:', error);
+            
+            // Determine error type and show appropriate message
+            if (error.name === 'AbortError' || error.name === 'TimeoutError') {
+                showErrorNotification("Request timed out. Please check if the Speechfire server is running.");
+            } else if (error.message.includes('Failed to fetch') || error.name === 'TypeError') {
+                showErrorNotification("Cannot connect to Speechfire server. Please ensure it's running on http://127.0.0.1:5000");
+            } else if (error.message.includes('Server error')) {
+                showErrorNotification(error.message);
+            } else {
+                showErrorNotification(`Transcription failed: ${error.message}`);
+            }
+        });
+    });
+}
+
+function testServerConnection() {
+    return fetch('http://127.0.0.1:5000/', {
+        method: 'GET',
+        signal: AbortSignal.timeout(100)
+    })
+    .then(response => {
+        return response.ok;
+    })
+    .catch(error => {
+        console.log('Server connection test failed:', error);
+        return false;
     });
 }
 
@@ -111,4 +171,73 @@ function simulatePaste(text) {
 
 function pasteTranscription(text) {
     simulatePaste(text);
+}
+
+function showErrorNotification(message) {
+    // Remove any existing error notifications
+    const existingNotification = document.getElementById('speechfire-error-notification');
+    if (existingNotification) {
+        existingNotification.remove();
+    }
+
+    // Create error notification element
+    const notification = document.createElement('div');
+    notification.id = 'speechfire-error-notification';
+    notification.style.cssText = `
+        position: fixed;
+        top: 20px;
+        right: 20px;
+        background: #ff4444;
+        color: white;
+        padding: 15px 20px;
+        border-radius: 8px;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        font-size: 14px;
+        font-weight: 500;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+        z-index: 10000;
+        max-width: 350px;
+        line-height: 1.4;
+        cursor: pointer;
+        transition: opacity 0.3s ease;
+    `;
+    
+    notification.innerHTML = `
+        <div style="display: flex; align-items: flex-start; gap: 10px;">
+            <div style="flex-shrink: 0; font-size: 16px;">🔥</div>
+            <div style="flex: 1;">
+                <div style="font-weight: 600; margin-bottom: 4px;">Speechfire Error</div>
+                <div style="margin-bottom: 8px;">${message}</div>
+                <a href="https://github.com/Jejkobb/Speechfire?tab=readme-ov-file#overview" 
+                   target="_blank" 
+                   style="color: #ffffff; text-decoration: underline; font-size: 12px; opacity: 0.9;">
+                   📖 View Setup Instructions
+                </a>
+            </div>
+            <div style="flex-shrink: 0; font-size: 18px; opacity: 0.7;">×</div>
+        </div>
+    `;
+
+    // Add click to dismiss (but not for links)
+    notification.addEventListener('click', (e) => {
+        if (e.target.tagName !== 'A') {
+            notification.style.opacity = '0';
+            setTimeout(() => notification.remove(), 300);
+        }
+    });
+
+    // Add to page
+    document.body.appendChild(notification);
+
+    // Auto-remove after 8 seconds
+    setTimeout(() => {
+        if (notification.parentNode) {
+            notification.style.opacity = '0';
+            setTimeout(() => {
+                if (notification.parentNode) {
+                    notification.remove();
+                }
+            }, 300);
+        }
+    }, 8000);
 }

--- a/server.py
+++ b/server.py
@@ -22,7 +22,7 @@ model = whisper.load_model("base", device=device)
 
 @app.route('/')
 def home():
-    return render_template('index.html')
+    return {"status": "Speechfire server is running", "version": "1.0"}
 
 @app.route('/transcribe', methods=['POST'])
 def transcribe():


### PR DESCRIPTION
## Summary
- Add server connection testing before recording starts to provide immediate feedback
- Show user-friendly error notifications with clickable link to setup instructions
- Prevent extension icon from turning red when server is unavailable  
- Add proper timeout handling (100ms for connection test, 30s for transcription)
- Fix Flask server to return JSON status instead of template error
- Add visual notifications with auto-dismiss and click-to-dismiss functionality

## Key Improvements
- **Immediate feedback**: Users get instant notification if server isn't running when they press Alt+A
- **Better UX**: Extension icon only turns red when recording actually starts (not on failed attempts)
- **Helpful errors**: Error notifications include link to GitHub setup instructions
- **Proper timeouts**: Quick connection test (100ms) vs transcription processing (30s)
- **Server fix**: `/` endpoint now returns proper JSON instead of 500 error

## Test plan
- [ ] Press Alt+A with server stopped - should show error immediately, icon stays white
- [ ] Press Alt+A with server running - should turn red and start recording normally
- [ ] Test transcription timeout handling with long audio files
- [ ] Verify error notification shows GitHub link that opens in new tab
- [ ] Test microphone permission errors

🤖 Generated with [Claude Code](https://claude.ai/code)